### PR TITLE
Initialize data before setting information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    google-protobuf (3.10.0-universal-darwin)
+    google-protobuf (3.11.1)
     googleapis-common-protos-types (1.0.4)
       google-protobuf (~> 3.0)
     grpc (1.24.0)

--- a/lib/grpc_access_logging_interceptor/server_interceptor.rb
+++ b/lib/grpc_access_logging_interceptor/server_interceptor.rb
@@ -22,16 +22,18 @@ module GrpcAccessLoggingInterceptor
     # @param [Method] method
     #
     def request_response(request:, call:, method:)
+      data = {} # Initialize at first to avoid nil
+
       accessed_at = Time.now
 
-      data = {
+      data.merge!({
         remote_addr:   remote_addr(call.peer),
         accessed_at:   accessed_at.utc.strftime('%Y-%m-%d %H:%M:%S.%6N'),
         params:        filter(request.to_h).to_json,
         user_agent:    call.metadata[USER_AGENT_KEY],
         grpc_method:   grpc_method(method),
         grpc_metadata: call.metadata.to_json,
-      }
+      })
       data.merge!(custom_data(request: request, call: call, method: method))
 
       yield


### PR DESCRIPTION
## WHY
Sometimes exception occurs when information is set to `data`. In this case, `data` becomes `nil`.

## WHAT
I separated the initialization and setting of information.