### PR TITLE
Use base64 when metadata is binary

### DIFF
--- a/lib/grpc_access_logging_interceptor/server_interceptor.rb
+++ b/lib/grpc_access_logging_interceptor/server_interceptor.rb
@@ -1,3 +1,4 @@
+require "base64"
 require "grpc"
 require "grpc_access_logging_interceptor/default_logger"
 
@@ -32,7 +33,7 @@ module GrpcAccessLoggingInterceptor
         params:        filter(request.to_h).to_json,
         user_agent:    call.metadata[USER_AGENT_KEY],
         grpc_method:   grpc_method(method),
-        grpc_metadata: call.metadata.to_json,
+        grpc_metadata: jsonize(call.metadata),
       })
       data.merge!(custom_data(request: request, call: call, method: method))
 
@@ -69,6 +70,21 @@ module GrpcAccessLoggingInterceptor
       # e.g. /google.pubsub.v2.PublisherService/CreateTopic.
       # cf. https://github.com/grpc/grpc/blob/v1.24.0/doc/PROTOCOL-HTTP2.md
       "/#{method.owner.service_name}/#{camelize(method.name.to_s)}"
+    end
+
+    # @param [Hash] metadata
+    # @return [String]
+    def jsonize(metadata)
+      h = {}
+      metadata.each do |k, v|
+        if v.is_a?(String) && v.encoding == Encoding::ASCII_8BIT
+          # If the value is binary, encode with Base64
+          h[k] = Base64.strict_encode64(v)
+        else
+          h[k] = v
+        end
+      end
+      h.to_json
     end
 
     # @param [String] term


### PR DESCRIPTION
## WHY
In current implementation, binary metadata is not supported.

## WHAT
Supported binary metadata.
When there is a binary data in metadata, we encode it with base64.