### PR TITLE
Encode with Base64 only when the value is invalid UTF-8

### DIFF
--- a/lib/grpc_access_logging_interceptor/server_interceptor.rb
+++ b/lib/grpc_access_logging_interceptor/server_interceptor.rb
@@ -78,8 +78,12 @@ module GrpcAccessLoggingInterceptor
       h = {}
       metadata.each do |k, v|
         if v.is_a?(String) && v.encoding == Encoding::ASCII_8BIT
-          # If the value is binary, encode with Base64
-          h[k] = Base64.strict_encode64(v)
+          begin
+            h[k] = v.encode(Encoding::UTF_8)
+          rescue Encoding::UndefinedConversionError
+            # If the value is binary, encode with Base64
+            h[k] = Base64.strict_encode64(v)
+          end
         else
           h[k] = v
         end

--- a/spec/grpc_access_logging_interceptor_spec.rb
+++ b/spec/grpc_access_logging_interceptor_spec.rb
@@ -16,7 +16,9 @@ describe GrpcAccessLoggingInterceptor do
     let(:request) { Google::Protobuf::StringValue.new(value: "World") }
     let(:call) { double(:call, peer: "ipv4:127.0.0.1:63634", metadata: metadata) }
     let(:metadata) {
-      { "user-agent" => "grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)" }
+      {
+        "user-agent" => "grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)".encode(Encoding::ASCII_8BIT),
+      }
     }
     let(:method) { service_class.new.method(:hello_rpc) }
     let(:service_class) {
@@ -118,7 +120,7 @@ describe GrpcAccessLoggingInterceptor do
       let(:options) { {} }
       let(:metadata) {
         {
-          "user-agent"  => "grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)",
+          "user-agent"  => "grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)".encode(Encoding::ASCII_8BIT),
           "binary-data" => [234].pack('c*'), # "\xEA", Binary data
         }
       }


### PR DESCRIPTION
## WHY
Want to use UTF-8 when the value of meta is valid UTF-8 String.

## WHAT
Updated the logic.
At first, we try the conversion to UTF-8. If it fails, then we encode it with Base64.