### PR TITLE
Use gmsc for converting a metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     grpc_access_logging_interceptor (0.0.4)
+      gmsc
       grpc
 
 GEM
@@ -9,6 +10,7 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
+    gmsc (0.0.1)
     google-protobuf (3.11.1)
     googleapis-common-protos-types (1.0.4)
       google-protobuf (~> 3.0)

--- a/grpc_access_logging_interceptor.gemspec
+++ b/grpc_access_logging_interceptor.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "google-protobuf"
   spec.add_development_dependency "timecop"
   spec.add_dependency "grpc"
+  spec.add_dependency "gmsc"
 end

--- a/spec/grpc_access_logging_interceptor_spec.rb
+++ b/spec/grpc_access_logging_interceptor_spec.rb
@@ -120,8 +120,8 @@ describe GrpcAccessLoggingInterceptor do
       let(:options) { {} }
       let(:metadata) {
         {
-          "user-agent"  => "grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)".encode(Encoding::ASCII_8BIT),
-          "binary-data" => [234].pack('c*'), # "\xEA", Binary data
+          "user-agent"      => "grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)".encode(Encoding::ASCII_8BIT),
+          "binary-data-bin" => [234].pack('c*'), # "\xEA", Binary data
         }
       }
 
@@ -132,7 +132,7 @@ describe GrpcAccessLoggingInterceptor do
         expect(mocked_logger.logged).to eq [
           {
             accessed_at:      "2019-03-15 00:00:00.000000",
-            grpc_metadata:    "{\"user-agent\":\"grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)\",\"binary-data\":\"6g==\"}",
+            grpc_metadata:    "{\"user-agent\":\"grpc-node/1.19.0 grpc-c/7.0.0 (linux; chttp2; gold)\",\"binary-data-bin\":\"6g==\"}",
             grpc_method:      "/test.Test/HelloRpc",
             grpc_status_code: 0,
             params:           "{\"value\":\"World\"}",


### PR DESCRIPTION
## WHY
I released [gmsc gem](https://github.com/south37/gmsc) . This can be used for converting metadata to a safe format. I want to use it in this gem.

## WHAT
Use gmsc for converting metadata.
